### PR TITLE
fix: return 404 when patient not found

### DIFF
--- a/patient-service/src/main/java/com/pm/patientservice/exception/GlobalExceptionHandler.java
+++ b/patient-service/src/main/java/com/pm/patientservice/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.pm.patientservice.exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,7 +17,7 @@ public class GlobalExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleValidationExeption(MethodArgumentNotValidException ex) {
+    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
         return ResponseEntity.badRequest().body(errors);
@@ -40,6 +41,6 @@ public class GlobalExceptionHandler {
 
         Map<String, String> errors = new HashMap<>();
         errors.put("message", "Patient not found");
-        return ResponseEntity.badRequest().body(errors);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errors);
     }
 }

--- a/patient-service/src/test/java/com/pm/patientservice/controller/PatientControllerTest.java
+++ b/patient-service/src/test/java/com/pm/patientservice/controller/PatientControllerTest.java
@@ -109,7 +109,7 @@ class PatientControllerTest {
     }
 
     @Test
-    void shouldReturnBadRequestWhenPatientNotFound() throws Exception {
+    void shouldReturnNotFoundWhenPatientNotFound() throws Exception {
         // Given
         UUID id = UUID.randomUUID();
         PatientRequestDTO request = createPatientRequest();
@@ -120,7 +120,7 @@ class PatientControllerTest {
         mockMvc.perform(put("/patients/{id}", id)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-               .andExpect(status().isBadRequest())
+               .andExpect(status().isNotFound())
                .andExpect(jsonPath("$.message").value("Patient not found"));
     }
 


### PR DESCRIPTION
## Summary
- return HTTP 404 from patient service when a patient is missing
- adjust controller test to expect not found response

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.pm:patient-service:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3c70cc48832388041c012185c3cb